### PR TITLE
Allow different source server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,31 @@ If you need different source and dest servers, this becomes:
         "dbPassword": "SOMEPASSWORD",
         "dbHost": "127.0.0.1"
       }
-    }    
+    }
+        
+If you need to prepare the connections, add an initialSql stanza:
+        
+    {
+      "source": {
+        "driver": "pdo_mysql",
+        "dbUser": "root",
+        "dbPassword": "SOMEPASSWORD",
+        "dbHost": "sourceDB.example.com",
+        "initialSql": [
+          "SET NAMES UTF8"
+        ]
+      },
+      "dest": {
+        "driver": "pdo_mysql",
+        "dbUser": "root",
+        "dbPassword": "SOMEPASSWORD",
+        "dbHost": "127.0.0.1",
+        "initialSql": [
+          "SET NAMES UTF8",
+          "SET foreign_key_checks = 0"
+        ]
+      }
+    }        
     
 ##### Sqlite
     

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ See `config/credentials.dist.json`:
       "dbHost": "127.0.0.1"
     }
     
+If you need different source and dest servers, this becomes:
+    
+    {
+      "source": {
+        "driver": "pdo_mysql",
+        "dbUser": "root",
+        "dbPassword": "SOMEPASSWORD",
+        "dbHost": "sourceDB.example.com"
+      },
+    
+      "dest" : {
+        "driver": "pdo_mysql",
+        "dbUser": "root",
+        "dbPassword": "SOMEPASSWORD",
+        "dbHost": "127.0.0.1"
+      }
+    }    
+    
 ##### Sqlite
     
 See `config/credentials.dist.json`:

--- a/src/App.php
+++ b/src/App.php
@@ -157,7 +157,7 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
                         'dbname' => $name,
                     ];
 
-                    if(!empty($dbcredentials->dbPort)) {
+                    if (!empty($dbcredentials->dbPort)) {
                         $params['port'] = $dbcredentials->dbPort;
                     }
                     break;
@@ -169,6 +169,12 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
             }
 
             $this["db.connections.$name"] = DriverManager::getConnection($params);
+
+            if (isset($dbcredentials->initialSql)) {
+                foreach($dbcredentials->initialSql as $command) {
+                    $this["db.connections.$name"]->exec($command);
+                }
+            }
         }
 
         return $this["db.connections.$name"];

--- a/src/App.php
+++ b/src/App.php
@@ -156,6 +156,10 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
                         'host' => $dbcredentials->dbHost,
                         'dbname' => $name,
                     ];
+
+                    if(!empty($dbcredentials->dbPort)) {
+                        $params['port'] = $dbcredentials->dbPort;
+                    }
                     break;
 
                 default:

--- a/src/App.php
+++ b/src/App.php
@@ -127,7 +127,9 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
     protected function createConnectionByDbName($name, $direction = self::CONNECTION_SOURCE)
     {
         if (!isset($this["db.connections.$name"])) {
-            $dbcredentials = isset($this["db.credentials"]->$direction) ? $this["db.credentials"]->$direction : $this["db.credentials"];
+            $dbcredentials = isset($this["db.credentials"]->$direction) ?
+                $this["db.credentials"]->$direction :
+                $this["db.credentials"];
 
             switch (isset($dbcredentials->driver) ? $dbcredentials->driver : 'pdo_mysql') {
                 case 'pdo_sqlite':
@@ -171,7 +173,7 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
             $this["db.connections.$name"] = DriverManager::getConnection($params);
 
             if (isset($dbcredentials->initialSql)) {
-                foreach($dbcredentials->initialSql as $command) {
+                foreach ($dbcredentials->initialSql as $command) {
                     $this["db.connections.$name"]->exec($command);
                 }
             }

--- a/src/App.php
+++ b/src/App.php
@@ -42,20 +42,8 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
             throw new \RuntimeException("Credentials file '$filename' could not be read");
         }
 
-        if ($credentials->driver === 'pdo_sqlite') {
-            if (isset($credentials->directory)) {
-                if (strpos($credentials->directory, DIRECTORY_SEPARATOR) !== 0) {
-                    // not an absolute path, treat as relative to sqlite file location
-                    $credentials->directory = realpath(
-                        dirname($filename) . DIRECTORY_SEPARATOR . $credentials->directory
-                    );
-                }
-            } else {
-                throw new \RuntimeException("Sqlite credentials file '$filename' must contain a directory");
-            }
-        }
-
         $this['db.credentials'] = $credentials;
+        $this['db.credentialsFile'] = $filename;
     }
 
     /**
@@ -99,7 +87,7 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
     }
 
     /**
-     * Create a connection class for a given DB name. Other credentials (host, password etc) must already be known
+     * Create source connection for a given DB name. Other credentials (host, password etc) must already be known
      *
      * @param string $name Database name
      *
@@ -107,17 +95,55 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
      * @throws \UnexpectedValueException If configuration is invalid
      * @throws \Doctrine\DBAL\DBALException If connection cannot be made
      */
-    public function createConnectionByDbName($name)
+    public function createSourceConnectionByDbName($name)
+    {
+        return $this->createConnectionByDbName($name, self::CONNECTION_SOURCE);
+    }
+
+    /**
+     * Create dest connection for a given DB name. Other credentials (host, password etc) must already be known
+     *
+     * @param string $name Database name
+     *
+     * @return Connection
+     * @throws \UnexpectedValueException If configuration is invalid
+     * @throws \Doctrine\DBAL\DBALException If connection cannot be made
+     */
+    public function createDestConnectionByDbName($name)
+    {
+        return $this->createConnectionByDbName($name, self::CONNECTION_DEST);
+    }
+
+    /**
+     * Create connection object for DB name / direction. Other credentials (host, password etc) must already be known
+     *
+     * @param string $name      Database name
+     * @param string $direction Determines whether 'source' or 'dest' credentials used, must be one of those values
+     *
+     * @return Connection
+     * @throws \UnexpectedValueException If configuration is invalid
+     * @throws \Doctrine\DBAL\DBALException If connection cannot be made
+     */
+    protected function createConnectionByDbName($name, $direction = self::CONNECTION_SOURCE)
     {
         if (!isset($this["db.connections.$name"])) {
-            switch (isset($this['db.credentials']->driver) ? $this['db.credentials']->driver : 'pdo_mysql') {
+            $dbcredentials = isset($this["db.credentials"]->$direction) ? $this["db.credentials"]->$direction : $this["db.credentials"];
+
+            switch (isset($dbcredentials->driver) ? $dbcredentials->driver : 'pdo_mysql') {
                 case 'pdo_sqlite':
-                    if (empty($this['db.credentials']->directory)) {
+                    if (empty($dbcredentials->directory)) {
                         throw new \UnexpectedValueException('Directory is required in sqlite configuration');
+                    } else {
+                        if (strpos($dbcredentials->directory, DIRECTORY_SEPARATOR) !== 0) {
+                            // not an absolute path, treat as relative to sqlite file location
+                            $dbcredentials->directory = realpath(
+                                dirname($this['db.credentialsFile']) . DIRECTORY_SEPARATOR . $dbcredentials->directory
+                            );
+                        }
                     }
                     $params = [
                         'driver' => 'pdo_sqlite',
-                        'path' => rtrim($this['db.credentials']->directory, DIRECTORY_SEPARATOR)
+                        'path' => rtrim($dbcredentials->directory, DIRECTORY_SEPARATOR)
                             . '/' . $name . '.sqlite',
                     ];
                     break;
@@ -125,16 +151,16 @@ class App extends Container implements DatabaseConnectionFactoryInterface, Logge
                 case 'pdo_mysql':
                     $params = [
                         'driver' => 'pdo_mysql',
-                        'user' => $this['db.credentials']->dbUser,
-                        'password' => $this['db.credentials']->dbPassword,
-                        'host' => $this['db.credentials']->dbHost,
+                        'user' => $dbcredentials->dbUser,
+                        'password' => $dbcredentials->dbPassword,
+                        'host' => $dbcredentials->dbHost,
                         'dbname' => $name,
                     ];
                     break;
 
                 default:
                     throw new \UnexpectedValueException(
-                        'Driver type "' . $this['db.credentials']->driver . '" not supported yet'
+                        'Driver type "' . $dbcredentials->driver . '" not supported yet'
                     );
             }
 

--- a/src/DatabaseConnectionFactoryInterface.php
+++ b/src/DatabaseConnectionFactoryInterface.php
@@ -5,6 +5,9 @@ use Doctrine\DBAL\Connection;
 
 interface DatabaseConnectionFactoryInterface
 {
+    const CONNECTION_SOURCE = 'source';
+    const CONNECTION_DEST = 'dest';
+
     /**
      * Create a connection class for a given DB name. Other credentials (host, password etc) must already be known
      *
@@ -12,5 +15,14 @@ interface DatabaseConnectionFactoryInterface
      *
      * @return Connection
      */
-    public function createConnectionByDbName($name);
+    public function createSourceConnectionByDbName($name);
+
+    /**
+     * Create a connection class for a given DB name. Other credentials (host, password etc) must already be known
+     *
+     * @param string $name Database name
+     *
+     * @return Connection
+     */
+    public function createDestConnectionByDbName($name);
 }

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -126,8 +126,8 @@ class Migrator implements LoggerAwareInterface
      */
     public function execute()
     {
-        $sourceConnection = $this->databaseConnectionFactory->createConnectionByDbName($this->sourceDb);
-        $destConnection = $this->databaseConnectionFactory->createConnectionByDbName($this->destinationDb);
+        $sourceConnection = $this->databaseConnectionFactory->createSourceConnectionByDbName($this->sourceDb);
+        $destConnection = $this->databaseConnectionFactory->createDestConnectionByDbName($this->destinationDb);
 
         $setName = $this->migrationSetName;
 

--- a/src/Sampler/CleanMatched.php
+++ b/src/Sampler/CleanMatched.php
@@ -26,6 +26,9 @@ class CleanMatched extends Matched
      */
     public function loadConfig($config)
     {
+        if (!isset($config->cleanFields)) {
+            throw new \RuntimeException("cleanFields missing for {$config->sampler}");
+        }
         $cleanSpec = (array)$config->cleanFields;
         $this->rowCleaner = RowCleaner::createFromSpecification($cleanSpec);
         parent::loadConfig($config);

--- a/tests/AppSetupTest.php
+++ b/tests/AppSetupTest.php
@@ -52,6 +52,8 @@ class AppSetupTest extends SqliteBasedTestCase
     {
         $app = new App();
         $app->loadCredentialsFile($this->fixturesDir . '/sqlite-credentials-no-dir.json');
+        $app->loadDatabaseConfigFile($this->fixturesDir . '/small_sqlite_migration.json');
+        $app->createDestConnectionByDbName('small-sqlite-source'); // directory tested at connection time now
     }
 
     /**
@@ -63,9 +65,26 @@ class AppSetupTest extends SqliteBasedTestCase
     {
         $app = new App();
         $app->loadCredentialsFile($this->fixturesDir . '/sqlite-credentials-relative-dir.json');
+        $app->loadDatabaseConfigFile($this->fixturesDir . '/small_sqlite_migration.json');
+        $app->createDestConnectionByDbName('small-sqlite-source');
+        // resolution of dirs now happens later
 
         $configuredPath = $app['db.credentials']->directory;
         $this->assertTrue(is_dir($configuredPath), "Sqlite relative directory path should resolve");
         $this->assertRegExp('#/tests/#', $configuredPath, 'Sqlite relative directory must resolve to full path');
+    }
+
+    /**
+     * Check that sqlite credential files handle source, dest DBs correctly
+     *
+     * @return void
+     */
+    public function testSqliteCredentialSourceDestDirectoryHandling()
+    {
+        $app = new App();
+        $app->loadCredentialsFile($this->fixturesDir . '/sqlite-credentials-source-dest.json');
+        $app->loadDatabaseConfigFile($this->fixturesDir . '/small_sqlite_migration.json');
+        $destConn = $app->createDestConnectionByDbName('small-sqlite-source');
+        $this->assertInstanceOf(\Doctrine\DBAL\Connection::class, $destConn);
     }
 }

--- a/tests/fixtures/sqlite-credentials-source-dest.json
+++ b/tests/fixtures/sqlite-credentials-source-dest.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "driver": "pdo_sqlite",
+    "directory": "sqlite-dbs"
+  },
+  "dest": {
+    "driver": "pdo_sqlite",
+    "directory": "sqlite-dbs"
+  }
+}


### PR DESCRIPTION
- Allow saving sampled DBs to a different server than the source
- Add support for a MySQL server running on non-standard port
- Read an initialSql stanza if present in the credentials to configure a DB connection (eg, character set)

