### PR TITLE
Include triggers in the table migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "pimple/pimple": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.0",
+        "friendsofphp/php-cs-fixer": "2.16.0",
         "phpunit/phpunit": "^5.7",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^2.7"

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -234,8 +234,7 @@ class Migrator implements LoggerAwareInterface
             $createSqlRow = $sourceConnection->query('SHOW CREATE TABLE ' . $sourceConnection->quoteIdentifier($table))
                 ->fetch(\PDO::FETCH_ASSOC);
             $createSql = $createSqlRow['Create Table'];
-            // find any triggers
-            $triggerSql = $this->checkTableTriggers($table, $sourceConnection);
+            $triggerSql = $this->generateTableTriggerSql($table, $sourceConnection);
         } elseif ($driverName === 'pdo_sqlite') {
             $schemaSql = 'SELECT SQL FROM sqlite_master WHERE NAME=' . $sourceConnection->quoteIdentifier($table);
             $createSql = $sourceConnection->query($schemaSql)->fetchColumn();
@@ -251,7 +250,7 @@ class Migrator implements LoggerAwareInterface
     }
 
     /**
-     * Look for any triggers and regenerate the SQL to create them
+     * Regenerate the SQL to create any triggers from the table
      *
      * @param string     $table            Table name
      * @param Connection $sourceConnection Originating DB connection
@@ -259,7 +258,7 @@ class Migrator implements LoggerAwareInterface
      * @return array
      * @throws \RuntimeException If DB type not supported
      */
-    private function checkTableTriggers($table, Connection $sourceConnection)
+    private function generateTableTriggerSql($table, Connection $sourceConnection)
     {
         $createTriggersSql = [];
 

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -267,7 +267,7 @@ class Migrator implements LoggerAwareInterface
         if ($driverName === 'pdo_mysql') {
             $triggers = $sourceConnection->fetchAll('SHOW TRIGGERS WHERE `Table`=' . $sourceConnection->quote($table));
             if ($triggers && count($triggers) > 0) {
-                foreach($triggers as $trigger) {
+                foreach ($triggers as $trigger) {
                     $sql = 'CREATE TRIGGER ' . $trigger['Trigger'] . ' ' . $trigger['Timing'] . ' ' . $trigger['Event'] .
                         ' ON ' . $sourceConnection->quoteIdentifier($trigger['Table']) . ' FOR EACH ROW ' .PHP_EOL . $trigger['Statement'] . '; ';
                     $createTriggersSql[] = $sql;
@@ -278,7 +278,7 @@ class Migrator implements LoggerAwareInterface
             $schemaSql = "select sql from sqlite_master where type = 'trigger' AND tbl_name=" . $sourceConnection->quote($table);
             $triggers = $sourceConnection->fetchAll($schemaSql);
             if ($triggers && count($triggers) > 0) {
-                foreach($triggers as $trigger) {
+                foreach ($triggers as $trigger) {
                     $createTriggersSql[] = $trigger['sql'];
                 }
             }


### PR DESCRIPTION
Extract trigger information from the source table and re-create the trigger(s) on the destination table.
Fixes #16.