### PR TITLE
Delay adding triggers to destination tables

### DIFF
--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -171,7 +171,7 @@ class Migrator implements LoggerAwareInterface
             $this->migrateView($view, $sourceConnection, $destConnection);
         }
 
-        $this->applyTriggersToDestTable($destConnection);
+        $this->applyTriggers($destConnection);
     }
 
     /**
@@ -257,16 +257,15 @@ class Migrator implements LoggerAwareInterface
      * Apply any stored table triggers to the destination database.
      * This should be done after the data has been inserted
      *
-     * @param Connection $destConnection   Target DB connection
+     * @param Connection $dbConnection   Target DB connection
      *
      * @return void
      * @throws \Doctrine\DBAL\DBALException If table trigger recreated
      */
-    private function applyTriggersToDestTable(Connection $destConnection)
+    private function applyTriggers(Connection $dbConnection)
     {
-        // create the triggers on the destination database table
         foreach ($this->tableTriggers as $sql) {
-            $destConnection->exec($sql);
+            $dbConnection->exec($sql);
         }
     }
 

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -247,7 +247,7 @@ class Migrator implements LoggerAwareInterface
     }
 
     /**
-     * Ensure that all table triggers from source are reccreated in the destination
+     * Ensure that all table triggers from source are recreated in the destination
      *
      * @param Connection $sourceConnection Originating DB connection
      * @param Connection $destConnection   Target DB connection

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -270,7 +270,7 @@ class Migrator implements LoggerAwareInterface
                     $destConnection->exec($sql);
                 }
                 if (count($triggerSql)) {
-                  $this->getLogger()->info("$this->migrationSetName: Migrated " . count($triggerSql) . " trigger(s) on $table");
+                    $this->getLogger()->info("$this->migrationSetName: Migrated " . count($triggerSql) . " trigger(s) on $table");
                 }
             } catch (\Exception $e) {
                 $this->getLogger()->error(

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -45,11 +45,6 @@ class Migrator implements LoggerAwareInterface
     protected $viewsToMigrate = [];
 
     /**
-     * @var string[]
-     */
-    protected $tableTriggers = [];
-
-    /**
      * Object that can create a Doctrine\DBAL\Connection from DB name
      *
      * @var DatabaseConnectionFactoryInterface


### PR DESCRIPTION
Creating tables with triggers before the data is inserted causes errors due to the triggers having dependancies on trying to act on tables that may not already exist.

This PR moves the creation of the triggers to after the data has been inserted in the migrated tables.