### PR TITLE
replace abandoned fzaninotto/faker with fakerphp/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "bin": ["bin/dbsampler"],
     "require": {
         "doctrine/dbal": "^2.5",
-        "fzaninotto/faker": "^1.6",
+        "fakerphp/faker": "^1.13",
         "monolog/monolog": "^1.22",
         "pimple/pimple": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "pimple/pimple": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.16.0",
+        "friendsofphp/php-cs-fixer": "^2.16",
         "phpunit/phpunit": "^5.7",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^2.7"


### PR DESCRIPTION
The original `fzaninotto/faker` library [has been archived](https://marmelab.com/blog/2020/10/21/sunsetting-faker.html) since Oct 2020, and [taken over by a Laravel-led community drive](https://laravel-news.com/changes-coming-to-php-faker).

As the [new library](https://github.com/fakerphp/faker) is a fork of the original, the APIs should be much the same